### PR TITLE
clippyでのチェックがちゃんと落ちるようにする

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -22,4 +22,4 @@ jobs:
           components: clippy
 
       - name: Run tests
-        run: cargo clippy --workspace --tests
+        run: cargo clippy --workspace --tests -- -D warnings


### PR DESCRIPTION
CIでclippyを用いたチェックをしていますが、現状は警告を無視しています
CIでのチェックにおいては警告が出たときはCIが落ちるというのが想定動作だと思うのでそのような動作にします