### PR TITLE
tokeiバイナリをキャッシュするように

### DIFF
--- a/.github/workflows/tokei.yml
+++ b/.github/workflows/tokei.yml
@@ -2,8 +2,8 @@ name: Send Current Tokei for Discord
 
 on:
   push:
-    branches:
-      - main
+    # branches: # TODO: マージ前に戻します
+    #   - main
 
 jobs:
   test:
@@ -13,16 +13,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache tokei binary
+        id: cache-tokei
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-tokei-bin
+          path: ~/.cargo/bin/tokei
+
       - name: Set up Rust
+        if: steps.cache-tokei.outputs.cache-hit != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install tokei
+        if: steps.cache-tokei.outputs.cache-hit != 'true'
         run: cargo install tokei
 
       - name: Run tokei
         id: tokei_result
-        run: tokei >> tokei_result.txt
+        run: ~/.cargo/bin/tokei >> tokei_result.txt
 
-      - name: Send to Discord
-        run: |
-          curl -X POST -H 'Content-type: application/json' --data "{\"content\": \"[現在](https://github.com/vsml-org/the_vsml_converter/tree/${{ github.sha }})のtokei\\n\`\`\`$(cat tokei_result.txt | tr '\n' '\\' | sed -r 's/\\/\\n/g')\`\`\`\"}" ${{ secrets.DISCORD_TOKEI_WEBHOOK }}
+      # - name: Send to Discord # TODO: マージ前に戻します
+      #   run: |
+      #     curl -X POST -H 'Content-type: application/json' --data "{\"content\": \"[現在](https://github.com/vsml-org/the_vsml_converter/tree/${{ github.sha }})のtokei\\n\`\`\`$(cat tokei_result.txt | tr '\n' '\\' | sed -r 's/\\/\\n/g')\`\`\`\"}" ${{ secrets.DISCORD_TOKEI_WEBHOOK }}

--- a/.github/workflows/tokei.yml
+++ b/.github/workflows/tokei.yml
@@ -2,8 +2,8 @@ name: Send Current Tokei for Discord
 
 on:
   push:
-    # branches: # TODO: マージ前に戻します
-    #   - main
+    branches:
+      - main
 
 jobs:
   test:
@@ -32,6 +32,6 @@ jobs:
         id: tokei_result
         run: ~/.cargo/bin/tokei >> tokei_result.txt
 
-      # - name: Send to Discord # TODO: マージ前に戻します
-      #   run: |
-      #     curl -X POST -H 'Content-type: application/json' --data "{\"content\": \"[現在](https://github.com/vsml-org/the_vsml_converter/tree/${{ github.sha }})のtokei\\n\`\`\`$(cat tokei_result.txt | tr '\n' '\\' | sed -r 's/\\/\\n/g')\`\`\`\"}" ${{ secrets.DISCORD_TOKEI_WEBHOOK }}
+      - name: Send to Discord
+        run: |
+          curl -X POST -H 'Content-type: application/json' --data "{\"content\": \"[現在](https://github.com/vsml-org/the_vsml_converter/tree/${{ github.sha }})のtokei\\n\`\`\`$(cat tokei_result.txt | tr '\n' '\\' | sed -r 's/\\/\\n/g')\`\`\`\"}" ${{ secrets.DISCORD_TOKEI_WEBHOOK }}


### PR DESCRIPTION
tokeiコマンドの結果をDiscordに送るWorkflowですが、cargo installを毎回行っているため実行に1分程かかっています
actions/cacheを利用してinstall済みバイナリをキャッシュすることでこれを高速にします