### PR TITLE
Rust 2024 editionにアップグレード

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace.package]
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 authors = ["PigeonsHouse"]
 
 [workspace]

--- a/vsml_audio_mixer/src/lib.rs
+++ b/vsml_audio_mixer/src/lib.rs
@@ -1,4 +1,4 @@
-use dasp::{interpolate::sinc::Sinc, ring_buffer, signal, slice::add_in_place, Signal};
+use dasp::{Signal, interpolate::sinc::Sinc, ring_buffer, signal, slice::add_in_place};
 use vsml_common_audio::Audio as VsmlAudio;
 use vsml_core::AudioEffectStyle;
 

--- a/vsml_cli/src/main.rs
+++ b/vsml_cli/src/main.rs
@@ -9,7 +9,7 @@ use vsml_core::schemas::ObjectProcessor;
 use vsml_encoder::encode;
 use vsml_image_renderer::RenderingContextImpl;
 use vsml_iv_converter::convert;
-use vsml_parser::{parse, VSSLoader};
+use vsml_parser::{VSSLoader, parse};
 use vsml_processer::audio::AudioProcessor;
 use vsml_processer::image::ImageProcessor;
 

--- a/vsml_encoder/src/lib.rs
+++ b/vsml_encoder/src/lib.rs
@@ -4,7 +4,7 @@ use temp_dir::TempDir;
 use vsml_common_audio::Audio as VsmlAudio;
 use vsml_common_image::Image as VsmlImage;
 use vsml_core::schemas::{IVData, ObjectData};
-use vsml_core::{mix_audio, render_frame_image, MixingContext, RenderingContext};
+use vsml_core::{MixingContext, RenderingContext, mix_audio, render_frame_image};
 use wgpu::util::DeviceExt;
 
 pub fn encode<R, M>(

--- a/vsml_iv_converter/src/lib.rs
+++ b/vsml_iv_converter/src/lib.rs
@@ -2,11 +2,11 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use vsml_ast::vsml::{Content, Element, Meta, VSML};
 use vsml_ast::vss::{Rule, VSSItem, VSSSelector, VSSSelectorTree};
+use vsml_core::ElementRect;
 use vsml_core::schemas::{
     Duration, IVData, LayerMode, ObjectData, ObjectProcessor, ObjectType, Order, RectSize,
     StyleData,
 };
-use vsml_core::ElementRect;
 
 pub fn convert<I, A>(
     vsml: &VSML,

--- a/vsml_parser/src/vss_parser.rs
+++ b/vsml_parser/src/vss_parser.rs
@@ -1,11 +1,11 @@
+use nom::IResult;
+use nom::Parser;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{crlf, newline, space1};
 use nom::combinator::{all_consuming, iterator, map, peek, success};
 use nom::multi::{many0, many1};
 use nom::sequence::terminated;
-use nom::IResult;
-use nom::Parser;
 use regex::Regex;
 use std::sync::LazyLock;
 use thiserror::Error;


### PR DESCRIPTION
2/20にリリースされたRust1.85にて2024 editionが使えるようになりました
https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html

非互換な変更が含まれていますが、基本的に新しいeditionのほうが良い挙動になっていることが多いはずなのでアップグレードします
用意されている自動migrationである `cargo fix` で差分が発生せず、テストも問題無く通るようなので問題無いと思います