### PR TITLE
ピクセルフォーマットをyuv420p指定にする

### DIFF
--- a/vsml_encoder/src/lib.rs
+++ b/vsml_encoder/src/lib.rs
@@ -109,6 +109,8 @@ pub fn encode<R, M>(
         .arg(d.join("audio.wav"))
         .arg("-vcodec")
         .arg("libx264")
+        .arg("-pix_fmt")
+        .arg("yuv420p")
         .arg("-acodec")
         .arg("aac")
         .arg(output_path)


### PR DESCRIPTION
スマホ端末など、ピクセルフォーマットがyuv444pである動画を再生できない端末がある
一番主流なピクセルフォーマットはyuv420pであり、スマホ端末や安価な端末などではそれ以外のピクセルフォーマットをサポートしていないケースもある
そのため、デフォルトではピクセルフォーマットをyuv420pとする
ただ、オプションでピクセルフォーマットを指定するのはまだ需要が低いと考え、まだ対応しない