### PR TITLE
DependabotでGitHub Actionsも更新する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
         update-types:
           - minor
           - patch
+  - package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+    groups:
+      default:
+        patterns:
+          - "*"


### PR DESCRIPTION
コミットハッシュ指定してないので別に要らないといえば要らないが、まあ設定したまま放置でいいなら入れるメリットのほうが大きいでしょうと思ったので