### PR TITLE
Dependabot: GitHub Actions用の設定にdirectoryを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
           - minor
           - patch
   - package-ecosystem: github-actions
+    directory: "/"
     schedule:
       interval: weekly
     groups:


### PR DESCRIPTION
follow-up: #53
必須のキー`directory`が足りていなくて落ちていました
たぶんこれでよいはず？