### PR TITLE
Cloudflare R2を使ってVRTをする

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -91,7 +91,7 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: |
-            r2 object put ${{ vars.VRT_CF_R2_BUCKET }}/visual-regression/images.tar.zst --file ./images.tar.zst
+            r2 object put ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/images.tar.zst --file ./images.tar.zst
 
   pr_checks:
     name: Visual regression checks for pull request
@@ -116,7 +116,7 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}
           command: |
-            r2 object get ${{ vars.VRT_CF_R2_BUCKET }}/visual-regression/images.tar.zst --file main-images.tar.zst
+            r2 object get ${{ secrets.VRT_CF_R2_BUCKET }}/visual-regression/images.tar.zst --file main-images.tar.zst
 
       - name: Run visual regression test
         shell: bash


### PR DESCRIPTION
close: #32 
https://github.com/reg-viz/reg-actions を利用してVisual Regression Testの構築を試みていましたが、これが微妙に要件を満たさなそうということで自前実装をやってみました

基本方針は
- mainブランチにpushされたとき
  - テスト対象の画像群をCloudflare R2に書き込み
- PullRequestが作られたとき
  - R2から画像をダウンロードしてきて`reg-cli`で差分比較
  - レポートのhtmlなどをCloudflare Pagesに公開
  - 差分情報のサマリーをコメント

という感じです

こんな感じに動きます
https://github.com/White-Green/the_vsml_converter/pull/2

TODO: 動作確認は私のフォークリポジトリ( https://github.com/White-Green/the_vsml_converter )のほうで行っていますが、こちらで動かすにあたってCloudflareアカウントなどの扱いをどうするか(いくつかsecretに設定する必要がある)マージ前に相談
Variableとして `VRT_CF_PAGES_PROJECT_NAME` 、Secretとして `CF_ACCOUNT_ID` `CF_API_TOKEN` `VRT_CF_R2_BUCKET` を設定すれば動きます