### PR TITLE
ビルドキャッシュを入れる

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ format('rust-{0}-target-clippy-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
+          key: ${{ format('rust-{0}-target-clippy-{1}-{2}', runner.os, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) }}
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('rust-{0}-target-clippy-', runner.os) }}
 
       - name: Run tests

--- a/.github/workflows/pages_doc.yml
+++ b/.github/workflows/pages_doc.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ format('rust-{0}-target-rustdoc-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
+          key: ${{ format('rust-{0}-target-rustdoc-{1}-{2}', runner.os, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) }}
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('rust-{0}-target-rustdoc-', runner.os) }}
 
       - name: Run rustdoc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ format('rust-{0}-target-test-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
+          key: ${{ format('rust-{0}-target-test-{1}-{2}', runner.os, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) }}
           restore-keys: ${{ github.ref_name != github.event.repository.default_branch && format('rust-{0}-target-test-', runner.os) }}
 
       - name: Run tests

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -44,9 +44,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-{2}-{3}', runner.os, github.event.pull_request.number, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) || format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
+          key: ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-{2}-{3}', runner.os, github.event.pull_request.number, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) || format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
           restore-keys: |
-            ${{ github.event_name == 'pull_request_target' && format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
+            ${{ github.event_name == 'pull_request_target' && format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) }}
             ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-', runner.os, github.event.pull_request.number) }}
             ${{ github.event_name == 'pull_request_target' && format('rust-{0}-target-vrt-', runner.os) }}
 


### PR DESCRIPTION
Rustのコンパイル時間はそこそこ長いので、キャッシュを入れるようにしました

キャッシュ対象などはこのへんを参考に、複数workflowで共有しても問題ないcargo registry部分を全workflow共有、共有してもあまり意味がないtarget配下を各workflow専有のキャッシュとしています
https://github.com/actions/cache/blob/main/examples.md#rust---cargo

一方keyの扱いはオリジナルでいろいろやっていて
- 処理時間の観点から、restore-keysを指定しておいていい感じに使いまわされて欲しい
- 適当にrestore-keysを指定するとキャッシュのサイズが肥大化していって10GBを超えたり、ランナーのストレージが足りなくなったりします(このプロジェクトでは当分問題ないだろうが、そうなったことがある...)

という事情から
- PRブランチではrestore-keysを指定してmainブランチのキャッシュをできるだけ活かす
- mainブランチではrestore-keys無しにして、処理時間には目をつぶって無駄のない最小限のキャッシュを作る

という方針の実装になっています

visual-regression.ymlだけ別物になっているのは、pull_request_targetトリガーだとmainブランチで起動するのでブランチ別のキャッシュ保存と同等の挙動を自前で作るためです(信頼できないコードによって生成されたキャッシュをmainなどから参照してしまうとまずいので)