### PR TITLE
cacheのkeyが一か所間違っていたので修正

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: target
-          key: ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-{2}-{3}', runner.os, github.event.pull_request.number, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) || format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.name, hashFiles('Cargo.lock')) }}
+          key: ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-{2}-{3}', runner.os, github.event.pull_request.number, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) || format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) }}
           restore-keys: |
             ${{ github.event_name == 'pull_request_target' && format('rust-{0}-target-vrt-{1}-{2}', runner.os, steps.rust-toolchain.outputs.cachekey, hashFiles('Cargo.lock')) }}
             ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-', runner.os, github.event.pull_request.number) }}


### PR DESCRIPTION
これはRustコンパイラのバージョンが上がったときにキャッシュを無効化することを意図したkey設定なんですが、.nameには`stable`などが入ってくるのでこれだと意図した挙動になりません
というのを #69 を作っている途中で気づいて修正したという経緯があるのですが、そのときの修正漏れがありました