### PR TITLE
VRTの画像キャプチャ処理をスクリプトに分ける

### DIFF
--- a/.ci/capture_vrt_images.sh
+++ b/.ci/capture_vrt_images.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+export WGPU_BACKEND=vulkan
+export RUST_BACKTRACE=full
+
+cargo build -p vsml_cli --release --locked
+
+EXAMPLES_DIR="$1"
+OUT_ROOT="$2"
+
+mkdir -p "${OUT_ROOT}"
+
+find "${EXAMPLES_DIR}" -mindepth 1 -maxdepth 1 -type d | while read -r dir; do
+  name="$(basename "$dir")"
+  echo "Processing example: $name"
+  # 相対参照( https://github.com/vsml-org/the_vsml_converter/issues/41 )の仕様が入っていないので、カレントディレクトリの移動が必要
+  pushd "$dir" > /dev/null
+  mkdir -p "${OUT_ROOT}/${name}"
+
+  # Pick the first .vsml file in the subdirectory
+  vsml_file="$(find "$dir" -maxdepth 1 -type f -name '*.vsml' | head -n 1 || true)"
+
+  if [ -z "$vsml_file" ]; then
+    echo "  -> No .vsml file found in $dir"
+    popd > /dev/null
+    continue
+  fi
+
+  out_mp4="/tmp/out.mp4"
+
+  echo "  -> Running vsml_cli on: $vsml_file"
+  target/release/vsml "$vsml_file" --output "$out_mp4" --overwrite
+
+  ffmpeg -hide_banner -loglevel error -y -i "$out_mp4" -vf fps=1 "${OUT_ROOT}/${name}/%04d.png"
+  ffmpeg -i "$out_mp4" -lavfi "showspectrumpic=s=1920x1080:legend=1" -y "${OUT_ROOT}/${name}/spectrogram.png"
+  popd > /dev/null
+done

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -50,39 +50,8 @@ jobs:
             ${{ github.event_name == 'pull_request_target' && format('rust-{0}-pr-{1}-target-vrt-', runner.os, github.event.pull_request.number) }}
             ${{ github.event_name == 'pull_request_target' && format('rust-{0}-target-vrt-', runner.os) }}
 
-      - name: Build vsml_cli
-        run: cargo build -p vsml_cli --release --locked
-
-      - name: Run vsml-cli for each example and post-process outputs
-        shell: bash
-        env:
-          WGPU_BACKEND: vulkan
-        run: |
-          set -euo pipefail
-          VSML_EXECUTABLE="$(pwd)/target/release/vsml"
-          EXAMPLES_DIR="$(pwd)/examples"
-          OUT_ROOT="$(pwd)/visual-regression/images"
-          mkdir -p "${OUT_ROOT}"
-
-          find "${EXAMPLES_DIR}" -mindepth 1 -maxdepth 1 -type d | while read -r dir; do
-            name="$(basename "$dir")"
-            echo "Processing example: $name"
-            # 相対参照( https://github.com/vsml-org/the_vsml_converter/issues/41 )の仕様が入っていないので、カレントディレクトリの移動が必要 
-            pushd "$dir"
-            mkdir -p "${OUT_ROOT}/${name}"
-
-            # Pick the first .vsml file in the subdirectory
-            vsml_file="$(find "$dir" -maxdepth 1 -type f -name '*.vsml' | head -n 1 || true)"
-
-            out_mp4="/tmp/out.mp4"
-
-            echo "  -> Running vsml_cli on: $vsml_file"
-            "$VSML_EXECUTABLE" "$vsml_file" --output "$out_mp4" --overwrite
-
-            ffmpeg -hide_banner -loglevel error -y -i "$out_mp4" -vf fps=1 "${OUT_ROOT}/${name}/%04d.png"
-            ffmpeg -i "$out_mp4" -lavfi "showspectrumpic=s=1920x1080:legend=1" -y "${OUT_ROOT}/${name}/spectrogram.png"
-            popd
-          done
+      - name: Capture visual regression images for each example
+        run: ./.ci/capture_vrt_images.sh "$(pwd)/examples" "$(pwd)/visual-regression/images"
 
       - name: Upload visual regression images
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
VRTの画像キャプチャ処理は`.github/workflows/visual-regression.yml`にべた書きされていましたが、これは`pull_request_target`トリガーで起動するので書き換えての動作確認のためにmainにマージする必要がありました
この状態を解消しキャプチャ処理に対する変更を入れやすくするため、別スクリプトに分けて呼び出すようにしました
これにより、スクリプトのほうに変更を入れればPull-Request内でも変更後のスクリプトが実行されるようになります

相対参照の実装やcliの引数追加などを行った際にキャプチャ処理にも手を入れる必要がありますがmainに入れるまで動作確認ができないのはつらいという背景があります