### PR TITLE
エンコード時のffmpegプロセスの標準入力を切る

### DIFF
--- a/vsml_encoder/src/lib.rs
+++ b/vsml_encoder/src/lib.rs
@@ -1,5 +1,5 @@
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use temp_dir::TempDir;
 use vsml_common_audio::Audio as VsmlAudio;
 use vsml_common_image::Image as VsmlImage;
@@ -117,6 +117,10 @@ pub fn encode<R, M>(
     let output_path = options.output_path.unwrap_or(Path::new("output.mp4"));
 
     let mut command = Command::new("ffmpeg");
+    command
+        .stdin(Stdio::null())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
     if options.overwrite {
         command.arg("-y");
     }


### PR DESCRIPTION
#86 でexampleがひとつ追加されたがVRTがうまく動いていない気配があり、手元でちょっといじったところ何かが標準入力に流し込まれていそうな気配なので切ってみます
もともと標準入力を受け付けていた(デフォルトはinherit)のが想定外だった感じではあるので