### PR TITLE
出力パス未指定時の出力先をpwd直下に

### DIFF
--- a/vsml_cli/src/main.rs
+++ b/vsml_cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use std::collections::HashMap;
 use std::env;
-use std::path::{self, PathBuf};
+use std::path::{self, Path, PathBuf};
 use std::sync::Arc;
 use vsml_audio_mixer::MixingContextImpl;
 use vsml_common_audio::Audio as VsmlAudio;
@@ -72,9 +72,12 @@ fn get_gpu_device() -> (wgpu::Device, wgpu::Queue) {
 fn main() {
     let args = Args::parse();
 
-    let output_path = args
-        .output_path
-        .map(|path| path::absolute(&path).expect("Failed to get output absolute path"));
+    let output_path = path::absolute(
+        args.output_path
+            .as_deref()
+            .unwrap_or(Path::new("output.mp4")),
+    )
+    .expect("Failed to get output absolute path");
     let vsml_string = std::fs::read_to_string(&args.input_path).unwrap();
     env::set_current_dir(args.input_path.parent().unwrap())
         .expect("Failed to set current directory");
@@ -113,7 +116,7 @@ fn main() {
         &mut rendering_context,
         &mut mixing_context,
         EncoderOptions {
-            output_path: output_path.as_deref(),
+            output_path: &output_path,
             overwrite: args.overwrite,
             ffmpeg_options: args.experimental_ffmpeg_output_option,
         },

--- a/vsml_encoder/src/lib.rs
+++ b/vsml_encoder/src/lib.rs
@@ -8,7 +8,7 @@ use vsml_core::{MixingContext, RenderingContext, mix_audio, render_frame_image};
 use wgpu::util::DeviceExt;
 
 pub struct EncoderOptions<'a> {
-    pub output_path: Option<&'a Path>,
+    pub output_path: &'a Path,
     pub overwrite: bool,
     pub ffmpeg_options: Vec<String>,
 }
@@ -114,7 +114,6 @@ pub fn encode<R, M>(
     writer.finalize().unwrap();
 
     let fps = iv_data.fps.to_string();
-    let output_path = options.output_path.unwrap_or(Path::new("output.mp4"));
 
     let mut command = Command::new("ffmpeg");
     command
@@ -148,7 +147,12 @@ pub fn encode<R, M>(
         command.args(options.ffmpeg_options);
     }
 
-    let status = command.arg(output_path).spawn().unwrap().wait().unwrap();
+    let status = command
+        .arg(options.output_path)
+        .spawn()
+        .unwrap()
+        .wait()
+        .unwrap();
     if !status.success() {
         panic!("FFmpeg command failed with status: {:?}", status);
     }


### PR DESCRIPTION
#82 において実行中にカレントディレクトリを移動するようになったことにより出力先が変わってしまいました
CLIのオプションとして出力先を渡されたときは絶対パスに変換することで回避しているので、未指定だった場合の出力先も絶対パスを利用するようにすることで同様に回避します